### PR TITLE
patch(mcp-client): use standard naming convention for windsurf

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm i -g tinyfoot tinyfoot-mcp-server create-tinyfoot-app
 
 ![Config options](documentation/tinyfoot-mcp-client-config.png)
 
-Use the command `npx @tonk/tinyfoot-mcp-client@0.1.0`
+Use the command `npx @tonk/tinyfoot-mcp-client@0.1.2`
 
 ## Usage
 

--- a/packages/tinyfoot-mcp-client/package.json
+++ b/packages/tinyfoot-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/tinyfoot-mcp-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The tinyfoot MCP client",
   "type": "module",
   "files": [

--- a/packages/tinyfoot-mcp-client/src/index.ts
+++ b/packages/tinyfoot-mcp-client/src/index.ts
@@ -48,7 +48,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       {
-        name: 'New tinyfoot task',
+        name: 'newTask',
         description:
           'Analyzes a user request and provides implementation guidance by finding relevant modules and providing project structure information. Use this whenever a user wants to create a new tinyfoot task.',
         inputSchema: zodToJsonSchema(TinyfootTaskSchema) as ToolInput,
@@ -72,7 +72,7 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
     }
 
     switch (name) {
-      case 'New tinyfoot task': {
+      case 'newTask': {
         try {
           // Find similar modules by querying the server
           const response = await fetch('http://localhost:4321/find-similar', {


### PR DESCRIPTION
### Description

This renames the tool in tinyfoot-mcp-client to follow a certain convention enforced by Windsurf.

### Other changes

Update the docs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@tonk/tinyfoot-mcp-client` package and modifies some text references within the documentation and code to reflect the new version and a change in task naming.

### Detailed summary
- Updated `version` from `0.1.1` to `0.1.2` in `packages/tinyfoot-mcp-client/package.json`.
- Changed usage command in `README.md` to `npx @tonk/tinyfoot-mcp-client@0.1.2`.
- Renamed task from `New tinyfoot task` to `newTask` in `packages/tinyfoot-mcp-client/src/index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->