### PR TITLE
fix: update instructions, add claude support, remove ollama generatio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Tinyfoot is in Alpha. This is a brand spanking new project being built fully in 
 
 ## Setup
 
-### Install ollama
+### Install ollama (optional if using MCP tool)
 
-Tinyfoot expects ollama to be installed with deepseek-r1:8b. This isn't a must have requirement, but the tooling may throw some errors along the way and the MCP server will not be able to provide as much context.
+Tinyfoot's MCP server expects ollama to be installed with deepseek-r1:8b.
 
 Please go to [https://ollama.com/](https://ollama.com/) to download and install.
 
@@ -52,6 +52,16 @@ npm i -g @tonk/tinyfoot-cli @tonk/tinyfoot-mcp-server @tonk/create-tinyfoot-app
 ```
 
 ### Install tinyfoot client into your code editor
+
+#### Claude Code
+
+If you are using Claude Code, then there is nothing you need to do. Just run
+
+```
+claude .
+```
+
+in the Tinyfoot app directory when you are ready.
 
 #### Cursor
 

--- a/packages/create-tinyfoot-app/package-lock.json
+++ b/packages/create-tinyfoot-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tonk/create-tinyfoot-app",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonk/create-tinyfoot-app",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/create-tinyfoot-app/src/index.ts
+++ b/packages/create-tinyfoot-app/src/index.ts
@@ -31,19 +31,6 @@ const projectQuestions = [
     ],
   },
   {
-    type: "checkbox",
-    name: "features",
-    message: "Select the features you need:",
-    choices: ["File Storage", "State Backup", "Multiplayer"],
-  },
-  {
-    type: "input",
-    name: "pages",
-    message: "List the main pages you want (comma-separated):",
-    filter: (input: string) =>
-      input.split(",").map((page: string) => page.trim()),
-  },
-  {
     type: "input",
     name: "description",
     message: "Briefly describe your project and its main functionality:",
@@ -51,87 +38,12 @@ const projectQuestions = [
 ];
 
 // Function to generate project plan using LLM
-interface ProjectAnswers {
-  projectType: string;
-  features: string[];
-  pages: string[];
-  description: string;
-}
-
-export async function generateProjectPlan(answers: ProjectAnswers) {
-  const prompt = `You are an expert in full stack development and local-first tooling. Based on the following project requirements, generate a structured implementation plan.
-    Prioritize keepsync and WebSocket for local-first development (info found in src/lib/keepsync/), and Tailwind for styling.
-    
-    Project Type: ${answers.projectType}
-    Features: ${answers.features.join(", ")}
-    Pages: ${answers.pages.join(", ")}
-    Description: ${answers.description}
-
-  //   Provide a response in this exact JSON format:
-  //   {
-  //     "components": [{ name: string, description: string }],
-  //     "views": [{ name: string, description: string }],
-  //     "state": [{ name: string, schema: object }]
-  //     "modules": [{ name: string, description: string }]
-  //   }
-
-  // Components are like the the pure UI pieces for our design system (e.g. button, navbar, dropdown, card)
-  // Views are the main pages of the application, so they describe parts of the application (e.g. landing, login, home, compose)
-  // State describes what should be the stateful pieces of the project (e.g. user profile, post listings, messages)
-  // Modules describe units of functionality that don't sit inside views, components or state (e.g. googleAPI, mathUtils, crypto)
-
-  //   Keep the response focused and practical. Include only essential components and libraries.`;
-
-  try {
-    const response = await fetch("http://localhost:11434/api/generate", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "deepseek-r1:8b",
-        prompt,
-        stream: false,
-        format: "json",
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Ollama request failed: ${response.statusText}`);
-    }
-
-    interface OllamaResponse {
-      response: string;
-      context?: number[];
-      created_at: string;
-      done: boolean;
-      model: string;
-      total_duration?: number;
-    }
-
-    const data = (await response.json()) as OllamaResponse;
-    const planJson = JSON.parse(data.response);
-
-    //   // the users original high-level description of the project
-    //   planJson.projectDescription = answers.description;
-
-    // Validate the response structure
-    return {
-      ...planJson,
-      description: answers.description,
-    };
-  } catch (error) {
-    console.error("Error generating project plan:", error);
-    // Fallback to a basic plan if LLM fails
-    return {
-      description: answers.description,
-      components: [],
-      views: [{ name: "Home", description: "A basic home page" }],
-      state: [],
-      modules: [],
-    };
-  }
-}
+// interface ProjectAnswers {
+//   projectType: string;
+//   features: string[];
+//   pages: string[];
+//   description: string;
+// }
 
 // Function to create project structure
 interface ProjectPlan {
@@ -268,6 +180,12 @@ export async function createProject(projectName: string, plan: ProjectPlan) {
     execSync("npm install", { stdio: "inherit" });
     spinner.succeed("Dependencies installed successfully!");
 
+    // Print next steps instructions
+    console.log("\n" + chalk.bold("🎉 Your Tinyfoot app is ready! 🎉"));
+    console.log("\n" + chalk.bold("Next steps:"));
+    console.log("  • " + chalk.cyan("npm run dev") + " - Start the development server");
+    console.log("  • You may launch claude code or any other AI editor in this directory to begin coding.\n");
+
     // Don't unref the process - we want the parent to wait for the child
   } catch (error) {
     spinner.fail(
@@ -290,9 +208,9 @@ program
       const answers = await inquirer.prompt(projectQuestions);
 
       // Generate project plan
-      const spinner = ora("Generating project plan...").start();
-      const plan = await generateProjectPlan(answers);
-      spinner.succeed("Project plan generated!");
+      // const spinner = ora("Generating project plan...").start();
+      const plan = answers
+      // spinner.succeed("Project plan generated!");
 
       // Create project with generated plan
       const finalProjectName = projectDirectory || answers.projectName;

--- a/packages/create-tinyfoot-app/templates/default/CLAUDE.md
+++ b/packages/create-tinyfoot-app/templates/default/CLAUDE.md
@@ -1,0 +1,2 @@
+IMPORTANT: Anytime you see a RECIPE.md file you should load it into your context. RECIPE.md files include similar types of information as CLAUDE.md files.
+IMPORTANT: Synchronization is best performed through the keepsync library. You must load the instructions for keepsync by reading instructions/keepsync/KEEPSYNC.md and looking at the examples in instructions/keepsync/examples

--- a/packages/create-tinyfoot-app/templates/default/RECIPE.md
+++ b/packages/create-tinyfoot-app/templates/default/RECIPE.md
@@ -13,3 +13,5 @@ router.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 ```
+
+The tinyfoot.config.json file includes useful information about the project and the project purpose.

--- a/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/KEEPSYNC.md
+++ b/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/KEEPSYNC.md
@@ -33,7 +33,7 @@ import { configureSyncEngine } from '@tonk/keepsync';
 
 // Configure the sync engine at application startup
 configureSyncEngine({
-  url: 'ws://localhost:8040',
+  url: 'ws://localhost:4080',
   name: 'MySyncEngine',
   onSync: (docId) => console.log(`Document ${docId} synced`),
   onError: (error) => console.error('Sync error:', error),
@@ -230,7 +230,7 @@ wss.on('connection', (ws) => {
 });
 
 // Start the server
-const PORT = process.env.PORT || 8040;
+const PORT = process.env.PORT || 4080;
 server.listen(PORT, () => {
   console.log(`Sync server running on port ${PORT}`);
 });

--- a/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/basic/counter.ts
+++ b/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/basic/counter.ts
@@ -12,7 +12,7 @@ interface CounterStore {
 // This can be done in a separate initialization file
 export function initializeSync() {
   configureSyncEngine({
-    url: "ws://localhost:3030/sync",
+    url: "ws://localhost:4080/sync",
     name: "MyApplication",
     dbName: "test_counter_example_db",
     onSync: (docId) => console.log(`Document ${docId} synced`),

--- a/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/files/FileManager.tsx
+++ b/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/files/FileManager.tsx
@@ -13,7 +13,7 @@ import { FileMetadata } from "@tonk/keepsync";
 export function initializeFileSync() {
   // Configure the sync engine
   configureSyncEngine({
-    url: "ws://localhost:3030/sync",
+    url: "ws://localhost:4080/sync",
     name: "FileManagerApplication",
     dbName: "file_manager_example_db",
     onSync: (docId) => console.log(`Document ${docId} synced`),

--- a/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/files/basicFileManager.ts
+++ b/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/files/basicFileManager.ts
@@ -14,7 +14,7 @@ import { FileMetadata } from "@tonk/keepsync";
 export function initializeFileSync() {
   // Configure the sync engine
   configureSyncEngine({
-    url: "ws://localhost:3030/sync",
+    url: "ws://localhost:4080/sync",
     name: "BasicFileManagerExample",
     dbName: "basic_file_manager_db",
     onSync: (docId) => console.log(`Document ${docId} synced`),

--- a/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/react/TodoApp.tsx
+++ b/packages/create-tinyfoot-app/templates/default/src/instructions/keepsync/examples/react/TodoApp.tsx
@@ -22,7 +22,7 @@ interface TodoStore {
 // Initialize the sync engine
 export function initializeTodoSync() {
   configureSyncEngine({
-    url: "ws://localhost:3030/sync",
+    url: "ws://localhost:4080/sync",
     name: "TodoApplication",
     onSync: (docId) => console.log(`Todo document ${docId} synced`),
     onError: (error) => console.error("Todo sync error:", error),


### PR DESCRIPTION
…n in the create-app tool

### Description

This updates the instructions for keepsync to fix port confusion.

### Other changes

Adds some files to help guide claude code.
Removes ollama from the create-tinyfoot-app cli
Updates the main README.md to be current.

### Tested

Manually tested

### Documentation

The main README.md has been changed to reflect the changes.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating configuration and instructions for the `tinyfoot` project, including version upgrades, URL changes for the sync engine, and enhancements to documentation and user guidance.

### Detailed summary
- Updated `version` from `0.1.5` to `0.1.6` in `package-lock.json`.
- Changed sync engine URL from `ws://localhost:3030/sync` to `ws://localhost:4080/sync` in multiple files.
- Added important notes in `CLAUDE.md` and `RECIPE.md`.
- Revised installation instructions in `README.md`.
- Removed unused code related to project plan generation in `index.ts`.
- Added next steps instructions after project creation in `createProject` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->