### PR TITLE
fix(create-app): fixes some small bugs

### DIFF
--- a/packages/create-tinyfoot-app/templates/default/src/index.tsx
+++ b/packages/create-tinyfoot-app/templates/default/src/index.tsx
@@ -18,8 +18,8 @@ if (process.env.NODE_ENV === "production") {
   unregisterServiceWorker();
 }
 
-configureSyncEngine({
-  url: "ws://localhost:3030/sync",
+await configureSyncEngine({
+  url: "ws://localhost:4080/sync",
   onSync: (docId) => console.log(`Document ${docId} synced`),
   onError: (error) => console.error("Sync error:", error),
 });

--- a/packages/create-tinyfoot-app/templates/default/tsconfig.json
+++ b/packages/create-tinyfoot-app/templates/default/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,
-    "target": "ES2020",
+    "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": [
-      "ES2020",
+      "ESNext",
       "DOM",
       "DOM.Iterable"
     ],
-    "module": "ES6",
+    "module": "ESNext",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/packages/create-tinyfoot-app/templates/default/webpack.config.cjs
+++ b/packages/create-tinyfoot-app/templates/default/webpack.config.cjs
@@ -85,7 +85,7 @@ module.exports = (env, argv) => {
       port: 3000,
       proxy: [{
         context: ['/sync', '/api'],
-        target: 'http://localhost:3030',
+        target: 'http://localhost:4080',
         ws: true,
         changeOrigin: true
       }],


### PR DESCRIPTION
### Description

There was an issue when using npx @tonk/create-tinyfoot-app with how arguments being handled.

### Other changes

Ports for sync service weren't universally updated.
Updated tsconfig to allow top-level awaits in template
await configSync in template