### PR TITLE
patch(create-app): version bump

### DIFF
--- a/packages/create-tinyfoot-app/package-lock.json
+++ b/packages/create-tinyfoot-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tonk/create-tinyfoot-app",
-  "version": "0.1.6",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonk/create-tinyfoot-app",
-      "version": "0.1.6",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/create-tinyfoot-app/package.json
+++ b/packages/create-tinyfoot-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create-tinyfoot-app",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "description": "Bootstrap your tinyfoot app",
   "type": "module",
   "bin": {

--- a/packages/create-tinyfoot-app/templates/default/package.json
+++ b/packages/create-tinyfoot-app/templates/default/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@automerge/automerge": "^2.2.8",
-    "@tonk/keepsync": "^0.1.2",
+    "@tonk/keepsync": "^0.2.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
### Description
Bumps the version of create-tinyfoot-app

### Other Changes

Bumps the version of keepsync used

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@tonk/create-tinyfoot-app` package and its dependencies, ensuring compatibility and potentially introducing new features or fixes.

### Detailed summary
- Updated `version` of `@tonk/create-tinyfoot-app` from `0.1.9` to `0.1.11` in `package.json`.
- Updated `version` of `@tonk/keepsync` from `0.1.2` to `0.2.0` in `templates/default/package.json`.
- Updated `version` of `@tonk/create-tinyfoot-app` from `0.1.6` to `0.1.11` in `package-lock.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->