### PR TITLE
fix(create-app): updates service-worker to actually cache

### DIFF
--- a/packages/create-tinyfoot-app/package.json
+++ b/packages/create-tinyfoot-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create-tinyfoot-app",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Bootstrap your tinyfoot app",
   "type": "module",
   "bin": {

--- a/packages/create-tinyfoot-app/templates/default/package.json
+++ b/packages/create-tinyfoot-app/templates/default/package.json
@@ -8,7 +8,7 @@
     "dev:client": "webpack serve --mode development",
     "dev:server": "tsx watch src/server.ts",
     "dev": "mprocs",
-    "build": "webpack --mode production",
+    "build": "webpack --mode production && node scripts/post-build-wasm-cache.cjs",
     "serve": "npm run build && node serve.cjs",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/create-tinyfoot-app/templates/default/scripts/post-build-wasm-cache.cjs
+++ b/packages/create-tinyfoot-app/templates/default/scripts/post-build-wasm-cache.cjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * This script ensures the correct WASM binary is cached by the service worker.
+ * It should be run after the webpack build process completes.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Configuration
+const distDir = path.resolve(__dirname, '../dist');
+const serviceWorkerPath = path.join(distDir, 'service-worker.js');
+
+// Find the WASM file in the dist directory
+function findWasmFile() {
+  const files = fs.readdirSync(distDir);
+  const wasmFile = files.find(file => file.endsWith('.wasm'));
+  
+  if (!wasmFile) {
+    console.error('No WASM file found in the dist directory');
+    process.exit(1);
+  }
+  
+  return wasmFile;
+}
+
+// Update the service worker to cache the correct WASM file
+function updateServiceWorker(wasmFile) {
+  if (!fs.existsSync(serviceWorkerPath)) {
+    console.error('Service worker file not found at:', serviceWorkerPath);
+    process.exit(1);
+  }
+
+  let swContent = fs.readFileSync(serviceWorkerPath, 'utf8');
+  
+  // Check if the service worker already contains a WASM file reference
+  const wasmPattern = /["']([^"']+\.wasm)["']/g;
+  const wasmMatches = [...swContent.matchAll(wasmPattern)];
+  
+  if (wasmMatches.length === 0) {
+    console.error('No WASM file reference found in service worker');
+    process.exit(1);
+  }
+
+  // Replace all occurrences of WASM files with the current one
+  for (const match of wasmMatches) {
+    const oldWasmPath = match[1];
+    // If the path starts with a slash, we need to add it to our replacement
+    const prefix = oldWasmPath.startsWith('/') ? '/' : '';
+    swContent = swContent.replace(oldWasmPath, `${prefix}${wasmFile}`);
+  }
+  
+  // Write the updated service worker back to disk
+  fs.writeFileSync(serviceWorkerPath, swContent);
+  console.log(`Service worker updated to cache WASM file: ${wasmFile}`);
+}
+
+// Main function
+function main() {
+  try {
+    console.log('Checking dist folder for WASM binary...');
+    const wasmFile = findWasmFile();
+    console.log(`Found WASM file: ${wasmFile}`);
+    
+    console.log('Updating service worker...');
+    updateServiceWorker(wasmFile);
+    
+    console.log('Post-build WASM cache update completed successfully');
+  } catch (error) {
+    console.error('Error updating WASM cache:', error);
+    process.exit(1);
+  }
+}
+
+// Run the script
+main(); 

--- a/packages/create-tinyfoot-app/templates/default/scripts/serve.cjs
+++ b/packages/create-tinyfoot-app/templates/default/scripts/serve.cjs
@@ -4,11 +4,11 @@ const port = process.env.PORT || 9999;
 const app = express();
 
 // Serve static files from the dist directory
-app.use(express.static(path.join(__dirname, 'dist')));
+app.use(express.static(path.join(__dirname, '..', 'dist')));
 
 // Send all requests to index.html so that client-side routing works
 app.get('*', function(req, res) {
-  res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+  res.sendFile(path.join(__dirname, '..', '/dist', 'index.html'));
 });
 
 app.listen(port);


### PR DESCRIPTION
### Description

This fixes the service-worker so that it will actually hold on to the data. PWA work now.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@tonk/create-tinyfoot-app` package, enhancing the build process and service worker functionality. It introduces a new script for caching WASM files and modifies the service worker to improve asset caching.

### Detailed summary
- Updated `version` in `package.json` from `0.1.11` to `0.1.12`.
- Modified the `build` script in `templates/default/package.json` to include a post-build WASM cache script.
- Changed static file serving paths in `serve.cjs`.
- Added a new script `post-build-wasm-cache.cjs` for caching WASM binaries.
- Updated asset caching logic in `service-worker.ts` to handle various file types and improve offline capabilities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->