### PR TITLE
fix(pwa): properly caches on gecko, webkit browsers, reliable pwa

### DIFF
--- a/packages/create-tinyfoot-app/package.json
+++ b/packages/create-tinyfoot-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create-tinyfoot-app",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Bootstrap your tinyfoot app",
   "type": "module",
   "bin": {

--- a/packages/create-tinyfoot-app/templates/default/src/service-worker.ts
+++ b/packages/create-tinyfoot-app/templates/default/src/service-worker.ts
@@ -43,6 +43,7 @@ sw.addEventListener("install", (event) => {
         "/bundle.js",
         "/icons/icon-192x192.png",
         "/icons/icon-512x512.png",
+        "/33ccdd41d7bef7110d12.module.wasm",
       ]);
     }),
   );

--- a/packages/create-tinyfoot-app/templates/default/src/serviceWorkerRegistration.ts
+++ b/packages/create-tinyfoot-app/templates/default/src/serviceWorkerRegistration.ts
@@ -28,32 +28,12 @@ export function registerServiceWorker() {
   }
 
   if ("serviceWorker" in navigator) {
-    // Check if this is a standalone PWA on iOS
-    const isIOSPWA = window.matchMedia("(display-mode: standalone)").matches;
-
-    // Check if this is the first launch after installation
-    const isFirstLaunch = !localStorage.getItem("pwaInitialized");
-
     const registerSW = () => {
       const swUrl = "/service-worker.js";
 
       navigator.serviceWorker
         .register(swUrl)
         .then((registration) => {
-          // For iOS PWAs on first launch, force cache all critical resources
-          if (isIOSPWA && isFirstLaunch) {
-            // Mark as initialized for future launches
-            localStorage.setItem("pwaInitialized", "true");
-
-            // Force cache warming for critical resources
-            if (registration.active) {
-              registration.active.postMessage({
-                type: "CACHE_WARMING",
-                payload: { forceUpdate: true },
-              });
-            }
-          }
-
           // Check for updates on page reload
           registration.addEventListener("updatefound", () => {
             const installingWorker = registration.installing;
@@ -68,11 +48,6 @@ export function registerServiceWorker() {
                   } else {
                     // Content is cached for offline use
                     console.log("Content is cached for offline use.");
-
-                    // For iOS PWAs, show a message to the user
-                    if (isIOSPWA && isFirstLaunch) {
-                      showIOSPWAMessage();
-                    }
                   }
                 }
               });
@@ -82,43 +57,6 @@ export function registerServiceWorker() {
         .catch((error) => {
           console.error("Error during service worker registration:", error);
         });
-    };
-
-    // Function to show a message for iOS PWA users
-    const showIOSPWAMessage = () => {
-      // Only show if we're in a standalone PWA on iOS
-      const isIOS =
-        /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-        (navigator.userAgent.includes("Mac") && "ontouchend" in document);
-
-      if (window.matchMedia("(display-mode: standalone)").matches && isIOS) {
-        const notification = document.createElement("div");
-        notification.style.position = "fixed";
-        notification.style.bottom = "20px";
-        notification.style.left = "50%";
-        notification.style.transform = "translateX(-50%)";
-        notification.style.backgroundColor = "#4a4a4a";
-        notification.style.color = "white";
-        notification.style.padding = "12px 20px";
-        notification.style.borderRadius = "8px";
-        notification.style.boxShadow = "0 2px 10px rgba(0,0,0,0.2)";
-        notification.style.zIndex = "9999";
-        notification.style.textAlign = "center";
-        notification.style.maxWidth = "90%";
-        notification.style.fontSize = "14px";
-
-        notification.textContent =
-          "App is ready for offline use! For best results, close the app completely and reopen.";
-
-        document.body.appendChild(notification);
-
-        // Remove after 8 seconds
-        setTimeout(() => {
-          if (notification.parentNode) {
-            notification.parentNode.removeChild(notification);
-          }
-        }, 8000);
-      }
     };
 
     if (document.readyState === "complete") {

--- a/packages/create-tinyfoot-app/templates/default/src/serviceWorkerRegistration.ts
+++ b/packages/create-tinyfoot-app/templates/default/src/serviceWorkerRegistration.ts
@@ -10,7 +10,6 @@ export function unregisterServiceWorker() {
     navigator.serviceWorker.ready
       .then((registration) => {
         registration.unregister();
-        console.log("Service worker unregistered");
       })
       .catch((error) => {
         console.error("Error unregistering service worker:", error);
@@ -18,27 +17,23 @@ export function unregisterServiceWorker() {
   }
 }
 
-// Check if service workers are supported in the current browser
 export function registerServiceWorker() {
   // In development mode, actively unregister any service workers
   if (!isProduction) {
     console.log(
-      "Development mode detected - unregistering any service workers"
+      "Development mode detected - unregistering any service workers",
     );
     unregisterServiceWorker();
     return;
   }
 
   if ("serviceWorker" in navigator) {
-    // Use a timeout to ensure the registration doesn't interfere with page load
-    window.addEventListener("load", () => {
+    const registerSW = () => {
       const swUrl = "/service-worker.js";
 
       navigator.serviceWorker
         .register(swUrl)
         .then((registration) => {
-          console.log("Service Worker registered: ", registration);
-
           // Check for updates on page reload
           registration.addEventListener("updatefound", () => {
             const installingWorker = registration.installing;
@@ -48,7 +43,7 @@ export function registerServiceWorker() {
                   if (navigator.serviceWorker.controller) {
                     // New content is available
                     console.log(
-                      "New content is available. Please refresh the page."
+                      "New content is available. Please refresh the page.",
                     );
                   } else {
                     // Content is cached for offline use
@@ -62,8 +57,27 @@ export function registerServiceWorker() {
         .catch((error) => {
           console.error("Error during service worker registration:", error);
         });
-    });
+    };
+
+    if (document.readyState === "complete") {
+      // Document already loaded, registering immediately
+      registerSW();
+    } else {
+      // Setting up load event listener
+      window.addEventListener("load", () => {
+        // Window load event fired
+        registerSW();
+      });
+
+      // Backup: also try after a short delay
+      setTimeout(() => {
+        if (!navigator.serviceWorker.controller) {
+          // No service worker controller found, trying registration again
+          registerSW();
+        }
+      }, 3000);
+    }
   } else {
-    console.log("Service workers are not supported in this browser.");
+    console.warn("Service workers are not supported in this browser.");
   }
 }

--- a/packages/create-tinyfoot-app/templates/default/src/serviceWorkerRegistration.ts
+++ b/packages/create-tinyfoot-app/templates/default/src/serviceWorkerRegistration.ts
@@ -28,12 +28,32 @@ export function registerServiceWorker() {
   }
 
   if ("serviceWorker" in navigator) {
+    // Check if this is a standalone PWA on iOS
+    const isIOSPWA = window.matchMedia("(display-mode: standalone)").matches;
+
+    // Check if this is the first launch after installation
+    const isFirstLaunch = !localStorage.getItem("pwaInitialized");
+
     const registerSW = () => {
       const swUrl = "/service-worker.js";
 
       navigator.serviceWorker
         .register(swUrl)
         .then((registration) => {
+          // For iOS PWAs on first launch, force cache all critical resources
+          if (isIOSPWA && isFirstLaunch) {
+            // Mark as initialized for future launches
+            localStorage.setItem("pwaInitialized", "true");
+
+            // Force cache warming for critical resources
+            if (registration.active) {
+              registration.active.postMessage({
+                type: "CACHE_WARMING",
+                payload: { forceUpdate: true },
+              });
+            }
+          }
+
           // Check for updates on page reload
           registration.addEventListener("updatefound", () => {
             const installingWorker = registration.installing;
@@ -48,6 +68,11 @@ export function registerServiceWorker() {
                   } else {
                     // Content is cached for offline use
                     console.log("Content is cached for offline use.");
+
+                    // For iOS PWAs, show a message to the user
+                    if (isIOSPWA && isFirstLaunch) {
+                      showIOSPWAMessage();
+                    }
                   }
                 }
               });
@@ -57,6 +82,43 @@ export function registerServiceWorker() {
         .catch((error) => {
           console.error("Error during service worker registration:", error);
         });
+    };
+
+    // Function to show a message for iOS PWA users
+    const showIOSPWAMessage = () => {
+      // Only show if we're in a standalone PWA on iOS
+      const isIOS =
+        /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+        (navigator.userAgent.includes("Mac") && "ontouchend" in document);
+
+      if (window.matchMedia("(display-mode: standalone)").matches && isIOS) {
+        const notification = document.createElement("div");
+        notification.style.position = "fixed";
+        notification.style.bottom = "20px";
+        notification.style.left = "50%";
+        notification.style.transform = "translateX(-50%)";
+        notification.style.backgroundColor = "#4a4a4a";
+        notification.style.color = "white";
+        notification.style.padding = "12px 20px";
+        notification.style.borderRadius = "8px";
+        notification.style.boxShadow = "0 2px 10px rgba(0,0,0,0.2)";
+        notification.style.zIndex = "9999";
+        notification.style.textAlign = "center";
+        notification.style.maxWidth = "90%";
+        notification.style.fontSize = "14px";
+
+        notification.textContent =
+          "App is ready for offline use! For best results, close the app completely and reopen.";
+
+        document.body.appendChild(notification);
+
+        // Remove after 8 seconds
+        setTimeout(() => {
+          if (notification.parentNode) {
+            notification.parentNode.removeChild(notification);
+          }
+        }, 8000);
+      }
     };
 
     if (document.readyState === "complete") {


### PR DESCRIPTION
### Description

- service worker install waits for `document.readyState === "complete"` instead of event listener on page load
  - this is because gecko and webkit have different timings than chromium
  - chromium prioritizes service workers over content loading, so the page load is called in time for the service worker
  - the others load content first, meaning the service worker doesn't even exist until after the page load event
- added wasm module to pre-cache to avoid cache optimizations made by webkit
  - this makes PWAs far more reliable, i haven't had any problems since
  - because i hard-coded the name of the wasm file, if it changes for whatever reason this fix will break
  - i recompiled multiple times to see if it's deterministic and it seems to be so far, but flagging this for the future

### Other changes

None

### Tested

Yes. Tested on Chromium, Gecko, and WebKit on macOS and iOS. Tested in Android Emulator. Works wonders.

### Related issues

- closes TON-924, TON-925

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the service worker registration process and versioning in the `create-tinyfoot-app` package, ensuring better handling of service worker registration and unregistration, along with a version bump in the `package.json`.

### Detailed summary
- Added a new WebAssembly module `33ccdd41d7bef7110d12.module.wasm` in `service-worker.ts`.
- Updated version in `package.json` from `0.1.12` to `0.1.13`.
- Improved `unregisterServiceWorker` function by removing console log statement.
- Refactored `registerServiceWorker` to use a helper function `registerSW`.
- Enhanced registration logic to handle document load state and added a timeout for registration retries.
- Changed console log to console warn for unsupported browsers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->